### PR TITLE
Allow for Errbit installations below root

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ require: {
 ## Usage
 
 To setup an Errbit instance you need to configure it with an array of parameters. 
-Only two of them are mandatory.
+Only `api_key` and `host` are mandatory.
 
 ``` php
 use Errbit\Errbit;
@@ -50,7 +50,8 @@ use Errbit\Errbit;
 Errbit::instance()
   ->configure(array(
     'api_key'           => 'YOUR API KEY',
-    'host'              => 'YOUR ERRBIT HOST, OR api.airbrake.io FOR AIRBRAKE'
+    'host'              => 'YOUR ERRBIT HOST, OR api.airbrake.io FOR AIRBRAKE',
+    'path'              => '/path/to/errbit', // if your instance is off the root of the domain
   ))
   ->start();
 ```

--- a/src/Errbit/Errbit.php
+++ b/src/Errbit/Errbit.php
@@ -220,6 +220,10 @@ class Errbit
         if (!isset($this->config['secure'])) {
             $this->config['secure'] = ($this->config['port'] == 443);
         }
+        
+        if (!isset($this->config['path'])) {
+            $this->config['path'] = '';
+        }
 
         if (empty($this->config['hostname'])) {
             $this->config['hostname'] = gethostname() ? gethostname() : '<unknown>';

--- a/src/Errbit/Errbit.php
+++ b/src/Errbit/Errbit.php
@@ -102,6 +102,7 @@ class Errbit
      *   - host
      *   - port
      *   - secure
+     *   - path
      *   - project_root
      *   - environment_name
      *   - url

--- a/src/Errbit/Writer/SocketWriter.php
+++ b/src/Errbit/Writer/SocketWriter.php
@@ -82,7 +82,7 @@ class SocketWriter implements WriterInterface
                 implode(
                     "\r\n",
                     array(
-                        sprintf('POST %s HTTP/1.1', self::NOTICES_PATH),
+                        sprintf('POST %s HTTP/1.1', $config['path'] . self::NOTICES_PATH),
                         sprintf('Host: %s', $config['host']),
                         sprintf('User-Agent: %s', $config['agent']),
                         sprintf('Content-Type: %s', 'text/xml'),


### PR DESCRIPTION
We have an Errbit installation accessible via `domain.com/errbit/`.

I couldn't see another way to do this easily without subclassing the SocketWriter which feels heavy-handed for the sake of one line.

Having this as a config option feels more natural.